### PR TITLE
ONLP: Update LED to display only front panel LED

### DIFF
--- a/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/ledi.c
+++ b/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/ledi.c
@@ -15,14 +15,7 @@ enum onlp_led_id
     LED_SYSTEM,
     LED_ALARM,
     LED_PSU,
-    LED_FAN,
-    LED_FAN_1,
-    LED_FAN_2,
-    LED_FAN_3,
-    LED_FAN_4,
-    LED_FAN_5,
-    LED_FAN_6,
-    LED_FAN_7
+    LED_FAN
 };
 
 /*
@@ -52,41 +45,6 @@ static onlp_led_info_t led_info[] =
         { ONLP_LED_ID_CREATE(LED_FAN), "FAN LED (Front)", 0 },
         ONLP_LED_STATUS_PRESENT,
         ONLP_LED_CAPS_AUTO | ONLP_LED_CAPS_ORANGE | ONLP_LED_CAPS_GREEN,
-    },
-    {
-        { ONLP_LED_ID_CREATE(LED_FAN_1), "FAN(1) LED", 0 },
-        ONLP_LED_STATUS_PRESENT,
-        ONLP_LED_CAPS_ON_OFF | ONLP_LED_CAPS_RED |  ONLP_LED_CAPS_GREEN | ONLP_LED_CAPS_AUTO,
-    },
-    {
-        { ONLP_LED_ID_CREATE(LED_FAN_2), "FAN(2) LED", 0 },
-        ONLP_LED_STATUS_PRESENT,
-        ONLP_LED_CAPS_ON_OFF | ONLP_LED_CAPS_RED |  ONLP_LED_CAPS_GREEN | ONLP_LED_CAPS_AUTO,
-    },
-    {
-        { ONLP_LED_ID_CREATE(LED_FAN_3), "FAN(3) LED", 0 },
-        ONLP_LED_STATUS_PRESENT,
-        ONLP_LED_CAPS_ON_OFF | ONLP_LED_CAPS_RED |  ONLP_LED_CAPS_GREEN | ONLP_LED_CAPS_AUTO,
-    },
-    {
-        { ONLP_LED_ID_CREATE(LED_FAN_4), "FAN(4) LED", 0 },
-        ONLP_LED_STATUS_PRESENT,
-        ONLP_LED_CAPS_ON_OFF | ONLP_LED_CAPS_RED |  ONLP_LED_CAPS_GREEN | ONLP_LED_CAPS_AUTO,
-    },
-    {
-        { ONLP_LED_ID_CREATE(LED_FAN_5), "FAN(5) LED", 0 },
-        ONLP_LED_STATUS_PRESENT,
-        ONLP_LED_CAPS_ON_OFF | ONLP_LED_CAPS_RED |  ONLP_LED_CAPS_GREEN | ONLP_LED_CAPS_AUTO,
-    },
-    {
-        { ONLP_LED_ID_CREATE(LED_FAN_6), "FAN(6) LED", 0 },
-        ONLP_LED_STATUS_PRESENT,
-        ONLP_LED_CAPS_ON_OFF | ONLP_LED_CAPS_RED |  ONLP_LED_CAPS_GREEN | ONLP_LED_CAPS_AUTO,
-    },
-    {
-        { ONLP_LED_ID_CREATE(LED_FAN_7), "FAN(7) LED", 0 },
-        ONLP_LED_STATUS_PRESENT,
-        ONLP_LED_CAPS_ON_OFF | ONLP_LED_CAPS_RED |  ONLP_LED_CAPS_GREEN | ONLP_LED_CAPS_AUTO,
     }
 };
 
@@ -141,26 +99,6 @@ onlp_ledi_info_get(onlp_oid_t id, onlp_led_info_t* info_p)
                 info_p->mode = current_mode+1;
             }
 
-            break;
-        case LED_FAN_1:
-        case LED_FAN_2:
-        case LED_FAN_3:
-        case LED_FAN_4:
-        case LED_FAN_5:
-        case LED_FAN_6:
-        case LED_FAN_7:
-
-            led_color = result & 0x3;
-
-            if(led_color == 3){
-                info_p->mode |= ONLP_LED_MODE_OFF;
-            }else if(led_color == 1){
-                info_p->mode |= ONLP_LED_MODE_GREEN;
-            }else if(led_color == 2){
-                info_p->mode |= ONLP_LED_MODE_RED;
-            }else if(led_color == 0){
-                info_p->mode |= ONLP_LED_MODE_AUTO;
-            }
             break;
         case LED_PSU:
         case LED_FAN:

--- a/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/platform.c
+++ b/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/platform.c
@@ -62,8 +62,7 @@ static const struct led_reg_mapper led_mapper[LED_COUNT + 1] = {
     {"LED_FAN_6", LED_FAN_6_H, 0x74},
     {"LED_FAN_7", LED_FAN_7_H, 0x84},
     {"LED_ALARM", LED_ALARM_H, ALARM_REGISTER},
-    {"LED_PSU_LEFT", LED_PSU_L_H, PSU_LED_REGISTER},
-    {"LED_PSU_RIGHT", LED_PSU_R_H, PSU_LED_REGISTER},
+    {"LED_PSU", LED_PSU_H, PSU_LED_REGISTER}
 };
 
 static const struct psu_reg_bit_mapper psu_mapper [PSU_COUNT + 1] = {

--- a/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/platform.c
+++ b/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/platform.c
@@ -54,15 +54,16 @@ static const struct fan_config_p fan_sys_reg[FAN_COUNT + 1] = {
 static const struct led_reg_mapper led_mapper[LED_COUNT + 1] = {
     {},
     {"LED_SYSTEM", LED_SYSTEM_H, LED_SYSTEM_REGISTER},
+    {"LED_ALARM", LED_ALARM_H, ALARM_REGISTER},
+    {"LED_PSU", LED_PSU_H, PSU_LED_REGISTER},
+    {"LED_FAN",LED_FAN_H,LED_FAN_REGISTER},
     {"LED_FAN_1", LED_FAN_1_H, 0x24},
     {"LED_FAN_2", LED_FAN_2_H, 0x34},
     {"LED_FAN_3", LED_FAN_3_H, 0x44},
     {"LED_FAN_4", LED_FAN_4_H, 0x54},
     {"LED_FAN_5", LED_FAN_5_H, 0x64},
     {"LED_FAN_6", LED_FAN_6_H, 0x74},
-    {"LED_FAN_7", LED_FAN_7_H, 0x84},
-    {"LED_ALARM", LED_ALARM_H, ALARM_REGISTER},
-    {"LED_PSU", LED_PSU_H, PSU_LED_REGISTER}
+    {"LED_FAN_7", LED_FAN_7_H, 0x84}
 };
 
 static const struct psu_reg_bit_mapper psu_mapper [PSU_COUNT + 1] = {
@@ -258,7 +259,7 @@ uint8_t getLEDStatus(int id)
         uint8_t result = 0;
         uint16_t led_stat_reg;
         led_stat_reg = led_mapper[id].dev_reg;
-        if(id >=2 && id <= 8){
+        if(id >=5 && id <= 11){
             fan_cpld_read_reg(led_stat_reg,&result);
         }else{
             result = read_register(led_stat_reg);

--- a/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/platform.c
+++ b/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/platform.c
@@ -56,14 +56,7 @@ static const struct led_reg_mapper led_mapper[LED_COUNT + 1] = {
     {"LED_SYSTEM", LED_SYSTEM_H, LED_SYSTEM_REGISTER},
     {"LED_ALARM", LED_ALARM_H, ALARM_REGISTER},
     {"LED_PSU", LED_PSU_H, PSU_LED_REGISTER},
-    {"LED_FAN",LED_FAN_H,LED_FAN_REGISTER},
-    {"LED_FAN_1", LED_FAN_1_H, 0x24},
-    {"LED_FAN_2", LED_FAN_2_H, 0x34},
-    {"LED_FAN_3", LED_FAN_3_H, 0x44},
-    {"LED_FAN_4", LED_FAN_4_H, 0x54},
-    {"LED_FAN_5", LED_FAN_5_H, 0x64},
-    {"LED_FAN_6", LED_FAN_6_H, 0x74},
-    {"LED_FAN_7", LED_FAN_7_H, 0x84}
+    {"LED_FAN",LED_FAN_H,LED_FAN_REGISTER}
 };
 
 static const struct psu_reg_bit_mapper psu_mapper [PSU_COUNT + 1] = {
@@ -258,12 +251,8 @@ uint8_t getLEDStatus(int id)
     {
         uint8_t result = 0;
         uint16_t led_stat_reg;
-        led_stat_reg = led_mapper[id].dev_reg;
-        if(id >=5 && id <= 11){
-            fan_cpld_read_reg(led_stat_reg,&result);
-        }else{
-            result = read_register(led_stat_reg);
-        }        
+        led_stat_reg = led_mapper[id].dev_reg; 
+        result = read_register(led_stat_reg);     
         ret = result;
     }
 

--- a/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/platform.h
+++ b/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/platform.h
@@ -20,7 +20,7 @@
 #define ALARM_REGISTER 0xA163
 
 //LED
-#define LED_COUNT   10
+#define LED_COUNT   11
 
 #define LED_SYSTEM_H  1
 #define LED_SYSTEM_REGISTER 0xA162
@@ -31,15 +31,17 @@
 #define LED_SYSTEM_4_HZ 2
 #define LED_SYSTEM_1_HZ 1
 
-#define LED_FAN_1_H   2
-#define LED_FAN_2_H   3
-#define LED_FAN_3_H   4
-#define LED_FAN_4_H   5
-#define LED_FAN_5_H   6
-#define LED_FAN_6_H   7
-#define LED_FAN_7_H   8
-#define LED_ALARM_H   9
-#define LED_PSU_H   10
+#define LED_FAN_H   4
+#define LED_FAN_REGISTER 0xA165
+#define LED_FAN_1_H   5
+#define LED_FAN_2_H   6
+#define LED_FAN_3_H   7
+#define LED_FAN_4_H   8
+#define LED_FAN_5_H   9
+#define LED_FAN_6_H   10
+#define LED_FAN_7_H   11
+#define LED_ALARM_H   2
+#define LED_PSU_H   3
 #define NELEMS(x)  (sizeof(x) / sizeof((x)[0]))
 
 #define ONLP_SENSOR_CACHE_SHARED "/onlp-sensor-cache-shared"

--- a/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/platform.h
+++ b/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/platform.h
@@ -20,7 +20,7 @@
 #define ALARM_REGISTER 0xA163
 
 //LED
-#define LED_COUNT   11
+#define LED_COUNT   4
 
 #define LED_SYSTEM_H  1
 #define LED_SYSTEM_REGISTER 0xA162
@@ -33,13 +33,6 @@
 
 #define LED_FAN_H   4
 #define LED_FAN_REGISTER 0xA165
-#define LED_FAN_1_H   5
-#define LED_FAN_2_H   6
-#define LED_FAN_3_H   7
-#define LED_FAN_4_H   8
-#define LED_FAN_5_H   9
-#define LED_FAN_6_H   10
-#define LED_FAN_7_H   11
 #define LED_ALARM_H   2
 #define LED_PSU_H   3
 #define NELEMS(x)  (sizeof(x) / sizeof((x)[0]))

--- a/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/platform.h
+++ b/packages/platforms/celestica/x86-64/x86-64-cel-silverstone/onlp/builds/src/module/src/platform.h
@@ -20,7 +20,7 @@
 #define ALARM_REGISTER 0xA163
 
 //LED
-#define LED_COUNT   11
+#define LED_COUNT   10
 
 #define LED_SYSTEM_H  1
 #define LED_SYSTEM_REGISTER 0xA162
@@ -39,8 +39,7 @@
 #define LED_FAN_6_H   7
 #define LED_FAN_7_H   8
 #define LED_ALARM_H   9
-#define LED_PSU_L_H   10
-#define LED_PSU_R_H   11
+#define LED_PSU_H   10
 #define NELEMS(x)  (sizeof(x) / sizeof((x)[0]))
 
 #define ONLP_SENSOR_CACHE_SHARED "/onlp-sensor-cache-shared"


### PR DESCRIPTION
Update the onlp on LED part following below register

For PSU LED and FAN STATUS LED

if bit 4 is 1 onlp will return as AUTO mode status.

PSU LED
![image](https://user-images.githubusercontent.com/33564710/65103650-1261e380-d9f9-11e9-86df-7c673eb051b5.png)

SYSTEM LED
![image](https://user-images.githubusercontent.com/33564710/65103677-2574b380-d9f9-11e9-9734-0ec279d6d20e.png)

ALARM LED
![image](https://user-images.githubusercontent.com/33564710/65103698-332a3900-d9f9-11e9-8891-62712a5e2139.png)

FAN LED
![image](https://user-images.githubusercontent.com/33564710/65103716-4210eb80-d9f9-11e9-9857-2f14c0a88667.png)


Log file: [led_silverstone_onlp_log.txt](https://github.com/pjaipakdee/OpenNetworkLinux/files/3624193/led_silverstone_onlp_log.txt)
